### PR TITLE
Develop/config: Add db and logger config

### DIFF
--- a/src/config/db.js
+++ b/src/config/db.js
@@ -1,0 +1,22 @@
+const mysql = require('mysql2/promise');
+const { logger } = require('./logger');
+
+const pool = mysql.createPool({
+  host: process.env.DB_HOST || '127.0.0.1',
+  user: process.env.DB_USER || 'root',
+  password: process.env.DB_PASS || '',
+  database: process.env.DB_NAME || 'teacher_student_db',
+  waitForConnections: true,
+  connectionLimit: 10,
+  queueLimit: 0,
+});
+
+pool.on('connection', () => {
+  logger.info('MySQL connection established');
+});
+
+pool.on('error', (err) => {
+  logger.error(`MySQL error: ${err.message}`);
+});
+
+module.exports = pool;

--- a/src/config/logger.js
+++ b/src/config/logger.js
@@ -1,0 +1,37 @@
+const { createLogger, format, transports } = require('winston');
+const { combine, timestamp, prettyPrint, json } = format;
+const rTracer = require('cls-rtracer');
+require('winston-daily-rotate-file');
+
+const rotateTransport = new transports.DailyRotateFile({
+  filename: 'logs/app-%DATE%.log',
+  datePattern: 'YYYY-MM-DD',
+  zippedArchive: true,
+  maxSize: '20m',
+  maxFiles: '30d',
+});
+
+const requestIdFormat = format((info) => {
+  info.requestId = rTracer.id();
+  return info;
+});
+
+const logger = createLogger({
+  level: process.env.NODE_ENV === 'development' ? 'debug' : 'info',
+  format: combine(requestIdFormat(), timestamp(), json()),
+  transports: [
+    new transports.Console({
+      format: prettyPrint({
+        colorize: true,
+      }),
+    }),
+    rotateTransport,
+  ],
+});
+
+// Provide per‑module/fn child logger
+function logWithContext(context = {}) {
+  return logger.child(context);
+}
+
+module.exports = { logger, logWithContext };


### PR DESCRIPTION
### ✨ Summary

This PR introduces and configures **MySQL connection pooling** and a **structured Winston logging system** to improve performance, maintainability, and observability of the application.

- - -

### ✅ Changes Introduced

#### 1\. **MySQL Connection Pooling**

*   Uses `mysql2/promise` to create a reusable connection pool (`config/db.js`).
    
*   Configured via environment variables:
    
    *   `DB_HOST`, `DB_USER`, `DB_PASS`, `DB_NAME`
        
*   Adds `pool.on('connection')` and `pool.on('error')` handlers:
    
    *   Logs successful DB connections and errors using the shared logger.
        

#### 2\. **Winston Logger with Context Support**

*   Introduces a centralized `logger` instance using `winston`.
    
*   Logs are:
    
    *   Structured in JSON for file logs.
        
    *   Pretty-printed in the console for development.
        
    *   Rotated daily with a 30-day retention period (`winston-daily-rotate-file`).
        
*   Automatically injects `requestId` (from `cls-rtracer`) into every log entry for traceability.
    
*   Adds a `logWithContext()` utility for per-module or per-feature scoped logging.
    

- - -

### 📦 New Dependencies

*   `mysql2`
    
*   `winston`
    
*   `winston-daily-rotate-file`
    
*   `cls-rtracer`
    

- - -

### 🛠️ Why This Is Needed

*   Improves **performance** and **resource management** through connection pooling.
    
*   Centralizes and standardizes **logging** for better monitoring and debugging.
    
*   Adds **request-level traceability** across logs using `requestId`.
    

- - -

### 🧪 How to Test

*   Ensure the database credentials are set in `.env`.
    
*   Verify that:
    
    *   Console logs are pretty-printed during development.
        
    *   Rotated logs are written to the `logs/` directory.
        
    *   `requestId` appears in logs when using `cls-rtracer` middleware.
        
    *   DB connections and queries work without leaking resources.
        